### PR TITLE
fix: css media queries on build

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -91,6 +91,12 @@ export default {
         // Report: https://github.com/jonathantneal/postcss-nesting/issues/41
         'postcss-nested': {},
 
+        /**
+         * PostCSS Custom Media lets you use Custom Media Queries in CSS, following the CSS Media Queries specification.
+         * https://github.com/postcss/postcss-custom-media
+         */
+        'postcss-custom-media': {},
+
         // Compression tool
         // https://github.com/cssnano/cssnano
         cssnano: {},
@@ -100,7 +106,7 @@ export default {
         stage: 1,
         // Instruct all plugins to omit pre-polyfilled CSS
         // https://github.com/csstools/postcss-preset-env#preserve
-        preserve: true,
+        preserve: false,
         features: {
           // Modify colors using the color-mod() function in CSS
           // https://github.com/jonathantneal/postcss-color-mod-function


### PR DESCRIPTION
For now, Custom Media Queries are not compiled by PostCSS on a bundling process. This changes truing to fix that.

![image](https://user-images.githubusercontent.com/3684889/129078264-a13ef3b4-1c49-4b0e-866b-5e8adfb04e10.png)
